### PR TITLE
Fix typo in build-alpine.yaml

### DIFF
--- a/.github/workflows/build-alpine.yaml
+++ b/.github/workflows/build-alpine.yaml
@@ -172,4 +172,4 @@ jobs:
         run: |
           docker push pandoc/alpine-latex:$PANDOC_VERSION
           docker tag pandoc/alpine-latex:$PANDOC_VERSION pandoc/latex:$PANDOC_VERSION
-          docke rpush pandoc/latex:$PANDOC_VERSION
+          docker push pandoc/latex:$PANDOC_VERSION


### PR DESCRIPTION
fix a typo in gha config so that `pandoc/latex` should be built